### PR TITLE
Fixed InputCsvReader after refactoring

### DIFF
--- a/Task/File/Csv/InputCsvReaderTask.php
+++ b/Task/File/Csv/InputCsvReaderTask.php
@@ -22,6 +22,8 @@ class InputCsvReaderTask extends CsvReaderTask
     /**
      * @param ProcessState $state
      *
+     * @TODO refactor to get file path outside of options
+     *
      * @throws \Symfony\Component\OptionsResolver\Exception\ExceptionInterface
      *
      * @return array

--- a/Task/File/Csv/InputCsvReaderTask.php
+++ b/Task/File/Csv/InputCsvReaderTask.php
@@ -29,7 +29,9 @@ class InputCsvReaderTask extends CsvReaderTask
     protected function getOptions(ProcessState $state)
     {
         $options = parent::getOptions($state);
-        $options['file_path'] = $this->getFilePath($options, $state->getInput());
+        if ($state->getInput() !== null) {
+            $options['file_path'] = $this->getFilePath($options, $state->getInput());
+        }
 
         return $options;
     }


### PR DESCRIPTION
InputCsvReader could not initialize because input is null at first (and defined in runtime)