### PR TITLE
Fixed MappingTransformer using multiple sub-transformers

### DIFF
--- a/Resources/tests/transfomer/mapping_transformer.yml
+++ b/Resources/tests/transfomer/mapping_transformer.yml
@@ -1,0 +1,42 @@
+clever_age_process:
+    configurations:
+        test.mapping_transformer.simple:
+            entry_point: transform
+            end_point: transform
+            tasks:
+                transform:
+                    service: '@cleverage_process.task.transformer'
+                    options:
+                        error_strategy: stop
+                        mapping:
+                            field2:
+                                code: '[field]'
+
+        test.mapping_transformer.error:
+            entry_point: transform
+            end_point: transform
+            tasks:
+                transform:
+                    service: '@cleverage_process.task.transformer'
+                    options:
+                        error_strategy: stop
+                        mapping:
+                            field2:
+                                code: 'probably_not_a_field'
+
+        test.mapping_transformer.multi_subtransformers:
+            entry_point: transform
+            end_point: transform
+            tasks:
+                transform:
+                    service: '@cleverage_process.task.transformer'
+                    options:
+                        error_strategy: stop
+                        mapping:
+                            field2:
+                                code: '[field]'
+                                transformers:
+                                    callback#1:
+                                        callback: array_filter
+                                    callback#2:
+                                        callback: array_reverse

--- a/Tests/Transformer/DateTransformersTest.php
+++ b/Tests/Transformer/DateTransformersTest.php
@@ -49,9 +49,7 @@ class DateTransformersTest extends AbstractProcessTest
      */
     public function testDateParserError()
     {
-        $result = $this->processManager->execute('test.date_transformers.date_parser', null, '2001-01-01T00:00:00+00:00');
-
-        dump($result);
+        $this->processManager->execute('test.date_transformers.date_parser', null, '2001-01-01T00:00:00+00:00');
     }
 
     /**

--- a/Tests/Transformer/MappingTransformerTest.php
+++ b/Tests/Transformer/MappingTransformerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace CleverAge\ProcessBundle\Tests\Transformer;
+
+use CleverAge\ProcessBundle\Tests\AbstractProcessTest;
+
+/**
+ * Tests for the MappingTransformer
+ */
+class MappingTransformerTest extends AbstractProcessTest
+{
+
+    /**
+     * Assert a simple mapping transformation, from one array to another
+     */
+    public function testSimpleMapping()
+    {
+        $result = $this->processManager->execute('test.mapping_transformer.simple', null, ['field' => 'value']);
+
+        self::assertEquals(['field2' => 'value'], $result);
+    }
+
+    /**
+     * Assert that if "ignore_missing" is false, then an error is thrown for missing fields
+     *
+     * @expectedException \RuntimeException
+     */
+    public function testMissingMapping()
+    {
+        $this->processManager->execute('test.mapping_transformer.error', null, ['field' => 'value']);
+    }
+
+    /**
+     * Assert we can use multiple times the same sub-transformer using # suffixes
+     */
+    public function testMultiSubtransformers()
+    {
+        $result = $this->processManager->execute('test.mapping_transformer.multi_subtransformers', null, ['field' => [3, null, 4, 2]]);
+
+        self::assertEquals(['field2' => [2, 4, 3]], $result);
+    }
+}

--- a/Transformer/MappingTransformer.php
+++ b/Transformer/MappingTransformer.php
@@ -31,9 +31,6 @@ class MappingTransformer implements ConfigurableTransformerInterface, Transforme
     /** @var PropertyAccessorInterface */
     protected $accessor;
 
-    /** @var array */
-    protected $transformerCodes;
-
     /**
      * @param PropertyAccessorInterface $accessor
      */
@@ -267,6 +264,17 @@ class MappingTransformer implements ConfigurableTransformerInterface, Transforme
     }
 
     /**
+     * This allows to use transformer codes suffixes to avoid limitations to the "transformers" option using codes as keys
+     * This way you can chain multiple times the same transformer. Without this, it would silently call only the 1st one.
+     *
+     * @example
+     * transformers:
+     *     callback#1:
+     *         callback: array_filter
+     *     callback#2:
+     *         callback: array_reverse
+     *
+     *
      * @param string $transformerCode
      *
      * @throws \CleverAge\ProcessBundle\Exception\MissingTransformerException
@@ -275,14 +283,7 @@ class MappingTransformer implements ConfigurableTransformerInterface, Transforme
      */
     protected function getCleanedTransfomerCode(string $transformerCode)
     {
-        if (!$this->transformerCodes) {
-            $this->transformerCodes = array_keys($this->transformerRegistry->getTransformers());
-        }
-        $pattern = sprintf(
-            '/(%s)(#[\d]+)?/',
-            implode('|', $this->transformerCodes)
-        );
-        $match = preg_match($pattern, $transformerCode, $parts);
+        $match = preg_match('/([^#]+)(#[\d]+)?/', $transformerCode, $parts);
 
         if (1 === $match && $this->transformerRegistry->hasTransformer($parts[1])) {
             return $parts[1];

--- a/Transformer/MappingTransformer.php
+++ b/Transformer/MappingTransformer.php
@@ -98,6 +98,7 @@ class MappingTransformer implements ConfigurableTransformerInterface, Transforme
                         try {
                             $transformedValue[$destKey] = $this->accessor->getValue($input, $srcKey);
                         } catch (\RuntimeException $missingPropertyError) {
+                            // @TODO no error if framework.property_access.throw_exception_on_invalid_index = false (default)
                             if ($mapping['ignore_missing'] || $options['ignore_missing']) {
                                 continue;
                             }
@@ -108,6 +109,7 @@ class MappingTransformer implements ConfigurableTransformerInterface, Transforme
                     try {
                         $transformedValue = $this->accessor->getValue($input, $sourceProperty);
                     } catch (\RuntimeException $missingPropertyError) {
+                        // @TODO no error if framework.property_access.throw_exception_on_invalid_index = false (default)
                         if ($mapping['ignore_missing'] || $options['ignore_missing']) {
                             continue;
                         }


### PR DESCRIPTION
Main issue detected:
* if a custom transformer was defined with a code containing an existing code, the existing code replaced the custom one
* example: a custom "default_value" transformer would be converted to existing DefaultTransformer (and could fail on option definition, or have a different execution!)

Also cleanup a debug code, added some quick test cases and found an important caveat.