### PR TITLE
Fixed context resolution to allow using complex values

### DIFF
--- a/Context/ContextualOptionResolver.php
+++ b/Context/ContextualOptionResolver.php
@@ -29,6 +29,7 @@ class ContextualOptionResolver
      */
     public function contextualizeOption($value, array $context)
     {
+        // Recursively parse options
         if (\is_array($value)) {
             return $this->contextualizeOptions($value, $context);
         }
@@ -36,6 +37,15 @@ class ContextualOptionResolver
         if (\is_string($value)) {
             $pattern = sprintf('/{{[ ]*(%s){1}[ ]*}}/', implode('|', array_keys($context)));
 
+            $matches = [];
+            $result = preg_match($pattern, $value, $matches);
+
+            // If it's an exact match, directly returns the value (allowing complex values such as an array)
+            if ($result && $matches[0] === $value) {
+                return $context[$matches[1]];
+            }
+
+            // Else use a replace to insert a string value into another
             return preg_replace_callback(
                 $pattern,
                 function ($matches) use ($context) {

--- a/Resources/tests/process/context.yml
+++ b/Resources/tests/process/context.yml
@@ -8,3 +8,31 @@ clever_age_process:
                     service: '@CleverAge\ProcessBundle\Task\ConstantOutputTask'
                     options:
                         output: '{{ value }}'
+
+        test.context.multi_values:
+            entry_point: data
+            end_point: data
+            tasks:
+                data:
+                    service: '@cleverage_process.task.constant_output'
+                    options:
+                        output: '{{ value1 }} is {{ value2 }}'
+
+        test.context.sub_value:
+            entry_point: data
+            end_point: data
+            tasks:
+                data:
+                    service: '@cleverage_process.task.constant_output'
+                    options:
+                        output:
+                            key: '{{ value }}'
+
+        test.context.merged_value:
+            entry_point: data
+            end_point: data
+            tasks:
+                data:
+                    service: '@cleverage_process.task.constant_output'
+                    options:
+                        output: 'value is {{ value }}'

--- a/Tests/ContextTest.php
+++ b/Tests/ContextTest.php
@@ -16,12 +16,60 @@ namespace CleverAge\ProcessBundle\Tests;
 class ContextTest extends AbstractProcessTest
 {
     /**
-     * Assert a value can correctly by passed through context
+     * Assert a value can correctly passed through context
      */
     public function testSimpleContext()
     {
         $result = $this->processManager->execute('test.context', 'ko', ['value' => 'ok']);
 
         self::assertEquals('ok', $result);
+
+        $result = $this->processManager->execute('test.context.sub_value', null, null, ['value' => 'ok']);
+
+        self::assertEquals(['key' => 'ok'], $result);
+    }
+
+    /**
+     * Assert a value can correctly passed and merged into a string, through context
+     */
+    public function testContextMergedValue()
+    {
+        $result = $this->processManager->execute('test.context.merged_value', null, null, ['value' => 'ok']);
+
+        self::assertEquals('value is ok', $result);
+    }
+
+    /**
+     * Assert 2 values can correctly passed and merged into a string, through context
+     */
+    public function testContextMultiValue()
+    {
+        $result = $this->processManager->execute('test.context.multi_values', null, null, ['value1' => 'red', 'value2' => 'dead']);
+
+        self::assertEquals('red is dead', $result);
+    }
+
+    /**
+     * Assert a complex value will fail while being merged into a string, through context
+     *
+     * @expectedException \RuntimeException
+     */
+    public function testContextCannotMergeValue()
+    {
+        $this->processManager->execute('test.context.merged_value', null, null, ['value' => ['another_key' => 'another_value']]);
+    }
+
+    /**
+     * Assert a complex value can correctly passed through context
+     */
+    public function testComplexContext()
+    {
+        $result = $this->processManager->execute('test.context', null, null, ['value' => ['another_key' => 'another_value']]);
+
+        self::assertEquals(['another_key' => 'another_value'], $result);
+
+        $result = $this->processManager->execute('test.context.sub_value', null, null, ['value' => ['another_key' => 'another_value']]);
+
+        self::assertEquals(['key' => ['another_key' => 'another_value']], $result);
     }
 }

--- a/Tests/ContextTest.php
+++ b/Tests/ContextTest.php
@@ -24,7 +24,7 @@ class ContextTest extends AbstractProcessTest
 
         self::assertEquals('ok', $result);
 
-        $result = $this->processManager->execute('test.context.sub_value', null, null, ['value' => 'ok']);
+        $result = $this->processManager->execute('test.context.sub_value', null, ['value' => 'ok']);
 
         self::assertEquals(['key' => 'ok'], $result);
     }
@@ -34,7 +34,7 @@ class ContextTest extends AbstractProcessTest
      */
     public function testContextMergedValue()
     {
-        $result = $this->processManager->execute('test.context.merged_value', null, null, ['value' => 'ok']);
+        $result = $this->processManager->execute('test.context.merged_value', null, ['value' => 'ok']);
 
         self::assertEquals('value is ok', $result);
     }
@@ -44,7 +44,7 @@ class ContextTest extends AbstractProcessTest
      */
     public function testContextMultiValue()
     {
-        $result = $this->processManager->execute('test.context.multi_values', null, null, ['value1' => 'red', 'value2' => 'dead']);
+        $result = $this->processManager->execute('test.context.multi_values', null, ['value1' => 'red', 'value2' => 'dead']);
 
         self::assertEquals('red is dead', $result);
     }
@@ -56,7 +56,7 @@ class ContextTest extends AbstractProcessTest
      */
     public function testContextCannotMergeValue()
     {
-        $this->processManager->execute('test.context.merged_value', null, null, ['value' => ['another_key' => 'another_value']]);
+        $this->processManager->execute('test.context.merged_value', null, ['value' => ['another_key' => 'another_value']]);
     }
 
     /**
@@ -64,11 +64,11 @@ class ContextTest extends AbstractProcessTest
      */
     public function testComplexContext()
     {
-        $result = $this->processManager->execute('test.context', null, null, ['value' => ['another_key' => 'another_value']]);
+        $result = $this->processManager->execute('test.context', null, ['value' => ['another_key' => 'another_value']]);
 
         self::assertEquals(['another_key' => 'another_value'], $result);
 
-        $result = $this->processManager->execute('test.context.sub_value', null, null, ['value' => ['another_key' => 'another_value']]);
+        $result = $this->processManager->execute('test.context.sub_value', null, ['value' => ['another_key' => 'another_value']]);
 
         self::assertEquals(['key' => ['another_key' => 'another_value']], $result);
     }


### PR DESCRIPTION
Currently there is a bug if you pass an array to a context