### PR TITLE
Mapping Transformer : allow directly a deep property path as mapping key

### DIFF
--- a/Resources/tests/transfomer/mapping_transformer.yml
+++ b/Resources/tests/transfomer/mapping_transformer.yml
@@ -40,3 +40,15 @@ clever_age_process:
                                         callback: array_filter
                                     callback#2:
                                         callback: array_reverse
+
+        test.mapping_transformer.deep_mapping:
+            entry_point: transform
+            end_point: transform
+            tasks:
+                transform:
+                    service: '@cleverage_process.task.transformer'
+                    options:
+                        error_strategy: stop
+                        mapping:
+                            "[field1][field2][field3]":
+                                code: '[value]'

--- a/Tests/Transformer/MappingTransformerTest.php
+++ b/Tests/Transformer/MappingTransformerTest.php
@@ -39,4 +39,14 @@ class MappingTransformerTest extends AbstractProcessTest
 
         self::assertEquals(['field2' => [2, 4, 3]], $result);
     }
+
+    /**
+     * Assert we can use a deep property path as a key to generate a multi-depth array
+     */
+    public function testDeepMapping()
+    {
+        $result = $this->processManager->execute('test.mapping_transformer.deep_mapping', null, ['value' => "ok"]);
+
+        self::assertEquals(['field1' => ["field2" => ["field3" => "ok"]]], $result);
+    }
 }

--- a/Transformer/MappingTransformer.php
+++ b/Transformer/MappingTransformer.php
@@ -134,10 +134,12 @@ class MappingTransformer implements ConfigurableTransformerInterface, Transforme
 
             if (\is_callable($options['merge_callback'])) {
                 $options['merge_callback']($result, $targetProperty, $transformedValue);
+            } elseif ($this->accessor->isWritable($result, $targetProperty)) {
+                $this->accessor->setValue($result, $targetProperty, $transformedValue);
             } elseif (\is_array($result)) {
                 $result[$targetProperty] = $transformedValue;
             } else {
-                $this->accessor->setValue($result, $targetProperty, $transformedValue);
+                throw new \UnexpectedValueException("Property '{$targetProperty}' is not writable");
             }
         }
 


### PR DESCRIPTION
Should allow mapping like below, without regressions
```
mapping:
    "[field1][field2][field3]":
        code: '[value]'
```