### PR TITLE
Skip subprocess errors & log

### DIFF
--- a/Resources/tests/process/blocking_tasks.yml
+++ b/Resources/tests/process/blocking_tasks.yml
@@ -33,7 +33,7 @@ clever_age_process:
 
         test.multiple_blocking:
             entry_point: data
-            end_point: aggregate2
+            end_point: aggregate3
             tasks:
                 data:
                     service: '@CleverAge\ProcessBundle\Task\ConstantIterableOutputTask'
@@ -43,7 +43,19 @@ clever_age_process:
 
                 aggregate:
                     service: '@CleverAge\ProcessBundle\Task\AggregateIterableTask'
+                    outputs: [iterate]
+
+                iterate:
+                    service: '@CleverAge\ProcessBundle\Task\InputIteratorTask'
                     outputs: [aggregate2]
 
                 aggregate2:
+                    service: '@CleverAge\ProcessBundle\Task\AggregateIterableTask'
+                    outputs: [iterate2]
+
+                iterate2:
+                    service: '@CleverAge\ProcessBundle\Task\InputIteratorTask'
+                    outputs: [aggregate3]
+
+                aggregate3:
                     service: '@CleverAge\ProcessBundle\Task\AggregateIterableTask'

--- a/Tests/BlockingTaskTest.php
+++ b/Tests/BlockingTaskTest.php
@@ -37,6 +37,12 @@ class BlockingTaskTest extends AbstractProcessTest
         self::assertEquals([['success']], $result);
     }
 
+    /**
+     * Assert a process with multiple blocking tasks can execute properly.
+     * Check
+     *  - a subsequent blocking task will be proceeded at least once
+     *  - a subsequent blocking task will be proceeded at most once
+     */
     public function testMultipleBlocking()
     {
         $result = $this->processManager->execute('test.multiple_blocking');


### PR DESCRIPTION
Allow to catch subprocess errors to pass input into an error branch.
Should we improve other error_strategy cases ?