### PR TITLE
Adding new features: log_level and default_error_strategy

### DIFF
--- a/Configuration/TaskConfiguration.php
+++ b/Configuration/TaskConfiguration.php
@@ -47,7 +47,7 @@ class TaskConfiguration
     protected $outputs = [];
 
     /** @var array */
-    protected $errors = [];
+    protected $errorOutputs = [];
 
     /** @var ProcessState */
     protected $state;
@@ -80,7 +80,7 @@ class TaskConfiguration
      * @param string $description
      * @param string $help
      * @param array  $outputs
-     * @param array  $errors
+     * @param array  $errorOutputs
      * @param string $errorStrategy
      * @param string $logLevel
      */
@@ -91,7 +91,7 @@ class TaskConfiguration
         string $description = '',
         string $help = '',
         array $outputs = [],
-        array $errors = [],
+        array $errorOutputs = [],
         string $errorStrategy = self::STRATEGY_SKIP,
         string $logLevel = LogLevel::CRITICAL
     ) {
@@ -101,7 +101,7 @@ class TaskConfiguration
         $this->description = $description;
         $this->help = $help;
         $this->outputs = $outputs;
-        $this->errors = $errors;
+        $this->errorOutputs = $errorOutputs;
         $this->errorStrategy = $errorStrategy;
         $this->logLevel = $logLevel;
         $this->logErrors = $logLevel !== LogLevel::DEBUG; // @deprecated, remove me in next version
@@ -187,11 +187,23 @@ class TaskConfiguration
     }
 
     /**
+     * @deprecated Use getErrorOutputs method instead
+     *
      * @return array
      */
     public function getErrors(): array
     {
-        return $this->errors;
+        @trigger_error('Deprecated method, use getErrorOutputs instead', E_USER_DEPRECATED);
+
+        return $this->getErrorOutputs();
+    }
+
+    /**
+     * @return array
+     */
+    public function getErrorOutputs(): array
+    {
+        return $this->errorOutputs;
     }
 
     /**

--- a/Configuration/TaskConfiguration.php
+++ b/Configuration/TaskConfiguration.php
@@ -12,6 +12,7 @@ namespace CleverAge\ProcessBundle\Configuration;
 
 use CleverAge\ProcessBundle\Model\ProcessState;
 use CleverAge\ProcessBundle\Model\TaskInterface;
+use Psr\Log\LogLevel;
 
 /**
  * Represents a task configuration inside a process
@@ -66,6 +67,9 @@ class TaskConfiguration
     /** @var string */
     protected $errorStrategy;
 
+    /** @var string */
+    protected $logLevel;
+
     /** @var bool */
     protected $logErrors;
 
@@ -78,7 +82,7 @@ class TaskConfiguration
      * @param array  $outputs
      * @param array  $errors
      * @param string $errorStrategy
-     * @param bool   $logErrors
+     * @param string $logLevel
      */
     public function __construct(
         $code,
@@ -89,7 +93,7 @@ class TaskConfiguration
         array $outputs = [],
         array $errors = [],
         string $errorStrategy = self::STRATEGY_SKIP,
-        bool $logErrors = true
+        string $logLevel = LogLevel::CRITICAL
     ) {
         $this->code = $code;
         $this->serviceReference = $serviceReference;
@@ -99,7 +103,8 @@ class TaskConfiguration
         $this->outputs = $outputs;
         $this->errors = $errors;
         $this->errorStrategy = $errorStrategy;
-        $this->logErrors = $logErrors;
+        $this->logLevel = $logLevel;
+        $this->logErrors = $logLevel !== LogLevel::DEBUG; // @deprecated, remove me in next version
     }
 
     /**
@@ -121,7 +126,7 @@ class TaskConfiguration
     /**
      * @return TaskInterface
      */
-    public function getTask(): TaskInterface
+    public function getTask(): ?TaskInterface
     {
         return $this->task;
     }
@@ -358,10 +363,22 @@ class TaskConfiguration
     }
 
     /**
+     * @return string
+     */
+    public function getLogLevel(): string
+    {
+        return $this->logLevel;
+    }
+
+    /**
+     * @deprecated Use getLogLevel instead
+     *
      * @return bool
      */
     public function isLogErrors(): bool
     {
+        @trigger_error('Deprecated method, use getLogLevel instead', E_USER_DEPRECATED);
+
         return $this->logErrors;
     }
 }

--- a/DependencyInjection/CleverAgeProcessExtension.php
+++ b/DependencyInjection/CleverAgeProcessExtension.php
@@ -39,5 +39,6 @@ class CleverAgeProcessExtension extends SidusBaseExtension
 
         $processConfigurationRegistry = $container->getDefinition(ProcessConfigurationRegistry::class);
         $processConfigurationRegistry->replaceArgument(0, $config['configurations']);
+        $processConfigurationRegistry->replaceArgument(1, $config['default_error_strategy']);
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@
 namespace CleverAge\ProcessBundle\DependencyInjection;
 
 use CleverAge\ProcessBundle\Configuration\TaskConfiguration;
+use Psr\Log\LogLevel;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -50,6 +51,7 @@ class Configuration implements ConfigurationInterface
 
         /** @var ArrayNodeDefinition $configurationsArrayDefinition */
         $configurationsArrayDefinition = $definition
+            ->scalarNode('default_error_strategy')->defaultValue(TaskConfiguration::STRATEGY_SKIP)->end()
             ->arrayNode('configurations')
             ->useAttributeAsKey('code')
             ->prototype('array');
@@ -105,6 +107,16 @@ class Configuration implements ConfigurationInterface
      */
     protected function appendTaskConfigDefinition(NodeBuilder $definition)
     {
+        $logLevels = [
+            LogLevel::EMERGENCY,
+            LogLevel::ALERT,
+            LogLevel::CRITICAL,
+            LogLevel::ERROR,
+            LogLevel::WARNING,
+            LogLevel::NOTICE,
+            LogLevel::INFO,
+            LogLevel::DEBUG,
+        ];
         $definition
             ->scalarNode('service')->isRequired()->end()
             ->scalarNode('description')->defaultValue('')->end()
@@ -112,7 +124,8 @@ class Configuration implements ConfigurationInterface
             ->arrayNode('options')->prototype('variable')->end()->end()
             ->arrayNode('outputs')->prototype('scalar')->defaultValue([])->end()->end()
             ->arrayNode('errors')->prototype('scalar')->defaultValue([])->end()->end()
-            ->scalarNode('error_strategy')->defaultValue(TaskConfiguration::STRATEGY_SKIP)->end()
-            ->booleanNode('log_errors')->defaultTrue()->end();
+            ->scalarNode('error_strategy')->defaultNull()->end()
+            ->enumNode('log_level')->values($logLevels)->defaultValue(LogLevel::CRITICAL)->end()
+            ->booleanNode('log_errors')->defaultTrue()->setDeprecated()->end();
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -122,8 +122,9 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('description')->defaultValue('')->end()
             ->scalarNode('help')->defaultValue('')->end()
             ->arrayNode('options')->prototype('variable')->end()->end()
-            ->arrayNode('outputs')->prototype('scalar')->defaultValue([])->end()->end()
-            ->arrayNode('errors')->prototype('scalar')->defaultValue([])->end()->end()
+            ->arrayNode('outputs')->prototype('scalar')->end()->end()
+            ->arrayNode('errors')->prototype('scalar')->end()->setDeprecated()->end()
+            ->arrayNode('error_outputs')->prototype('scalar')->end()->end()
             ->scalarNode('error_strategy')->defaultNull()->end()
             ->enumNode('log_level')->values($logLevels)->defaultValue(LogLevel::CRITICAL)->end()
             ->booleanNode('log_errors')->defaultTrue()->setDeprecated()->end();

--- a/Documentation/reference/02-task_definition.md
+++ b/Documentation/reference/02-task_definition.md
@@ -13,7 +13,8 @@ YAML Configuration
     outputs: <list of following task codes>
     errors: <list of following task codes>
     error_strategy: <skip|stop>
-    log_errors: <true|false>
+    log_errors: <true|false> # Deprecated
+    log_level: <emergency|alert|critical|error|warning|notice|info|debug>
 ```
 
 Process attributes
@@ -33,4 +34,7 @@ Process attributes
 
 **error_strategy**: either *skip* (default) or *stop*, defines if a task can be continued or not
 
-**log_errors**: optional boolean (defaults to true), to allow logging thrown errors
+**log_errors**: DEPRECATED: use log_level instead. Optional boolean (defaults to true), to allow logging thrown errors
+
+**log_level**: rfc5424 severity (emergency, alert, critical, error, warning, notice, info, debug) for error logged when
+an exception is thrown by a task. Default 'critical'. Case-independant.

--- a/Logger/AbstractProcessor.php
+++ b/Logger/AbstractProcessor.php
@@ -1,14 +1,18 @@
 <?php
+/*
+ * This file is part of the CleverAge/ProcessBundle package.
+ *
+ * Copyright (C) 2017-2018 Clever-Age
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace CleverAge\ProcessBundle\Logger;
 
 use CleverAge\ProcessBundle\Manager\ProcessManager;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * Class AbstractProcessor
- *
- * @package CleverAge\ProcessBundle\Logger
  * @author  Madeline Veyrenc <mveyrenc@clever-age.com>
  */
 class AbstractProcessor
@@ -16,25 +20,17 @@ class AbstractProcessor
     /** @var ProcessManager */
     protected $processManager;
 
-    /** @var NormalizerInterface */
-    protected $normalizer;
-
     /**
-     * AbstractProcessor constructor.
-     *
-     * @param ProcessManager      $processManager
-     * @param NormalizerInterface $normalizer
+     * @param ProcessManager $processManager
      */
-    public function __construct(
-        ProcessManager $processManager,
-        NormalizerInterface $normalizer
-    ) {
+    public function __construct(ProcessManager $processManager)
+    {
         $this->processManager = $processManager;
-        $this->normalizer = $normalizer;
     }
 
     /**
      * @param array $record
+     *
      * @return array
      */
     public function __invoke(array $record)
@@ -54,6 +50,7 @@ class AbstractProcessor
 
     /**
      * @param array $record
+     *
      * @return array
      */
     protected function normalizeRecordData(array $record): array
@@ -68,6 +65,7 @@ class AbstractProcessor
 
     /**
      * @param array $record
+     *
      * @return void
      */
     protected function addProcessInfoToRecord(array &$record): void
@@ -84,6 +82,7 @@ class AbstractProcessor
 
     /**
      * @param array $record
+     *
      * @return void
      */
     protected function addTaskInfoToRecord(array &$record): void
@@ -112,19 +111,11 @@ class AbstractProcessor
      * @param array  $record
      * @param string $name
      * @param mixed  $data
+     *
      * @return void
      */
     protected function addToRecord(array &$record, $name, $data): void
     {
-        if (!array_key_exists($name, $record)) {
-            if ($this->normalizer->supportsNormalization($data, 'json')) {
-                $record[$name] = $this->normalizer->normalize(
-                    $data,
-                    'json'
-                );
-            } else {
-                $record[$name] = json_decode(json_encode($data), true);
-            }
-        }
+        $record[$name] = $data;
     }
 }

--- a/Logger/AbstractProcessor.php
+++ b/Logger/AbstractProcessor.php
@@ -99,8 +99,8 @@ class AbstractProcessor
         if (!$state) {
             return;
         }
-        if ($state->hasError()) {
-            $this->addToRecord($record, 'error', $state->getError());
+        if ($state->hasErrorOutput()) {
+            $this->addToRecord($record, 'error', $state->getErrorOutput());
         }
 
         if ($state->getException()) {

--- a/Manager/ProcessManager.php
+++ b/Manager/ProcessManager.php
@@ -224,6 +224,12 @@ class ProcessManager
      */
     protected function initialize(TaskConfiguration $taskConfiguration): void
     {
+        if ($taskConfiguration->getErrorStrategy() === TaskConfiguration::STRATEGY_STOP
+            && \count($taskConfiguration->getErrorOutputs()) > 0) {
+            $m = "Task configuration {$taskConfiguration->getCode()} has error outputs ";
+            $m .= "but it's error strategy 'stop' implies they will never be reached.";
+            $this->logger->error($m);
+        }
         // @todo Refactor this using a Registry with this feature:
         // https://symfony.com/doc/current/service_container/service_subscribers_locators.html
         $serviceReference = $taskConfiguration->getServiceReference();

--- a/Manager/ProcessManager.php
+++ b/Manager/ProcessManager.php
@@ -389,10 +389,7 @@ class ProcessManager
             $exception = $e;
         }
         if ($exception) {
-            if ($taskConfiguration->isLogErrors()) {
-                // @todo make the log level configurable and change logger channel
-                $this->logger->critical($exception->getMessage(), $state->getErrorContext());
-            }
+            $this->logger->log($taskConfiguration->getLogLevel(), $exception->getMessage(), $state->getErrorContext());
             if ($taskConfiguration->getErrorStrategy() === TaskConfiguration::STRATEGY_SKIP) {
                 $state->setSkipped(true);
                 if (null === $state->getErrorOutput()) {

--- a/Model/ProcessState.php
+++ b/Model/ProcessState.php
@@ -172,6 +172,41 @@ class ProcessState
     }
 
     /**
+     * @deprecated Use getErrorOutput instead
+     *
+     * @return mixed
+     */
+    public function getError()
+    {
+        @trigger_error('Deprecated method, use getErrorOutput instead', E_USER_DEPRECATED);
+
+        return $this->getErrorOutput();
+    }
+
+    /**
+     * @deprecated Use setErrorOutput instead
+     *
+     * @param mixed $error
+     */
+    public function setError($error)
+    {
+        @trigger_error('Deprecated method, use setErrorOutput instead', E_USER_DEPRECATED);
+
+        $this->setErrorOutput($error);
+    }
+
+    /**
+     * @deprecated Use hasErrorOutput instead
+     *
+     * @return bool
+     */
+    public function hasError()
+    {
+        @trigger_error('Deprecated method, use hasErrorOutput instead', E_USER_DEPRECATED);
+
+        return $this->hasErrorOutput();
+    }
+    /**
      * @return mixed
      */
     public function getErrorOutput()

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ clever_age_process:
                     error_strategy: skip
                     
                     # Logs any errors encountered
-                    log_errors: true
+                    log_level: critical
 
                 # More tasks
 ```

--- a/Registry/ProcessConfigurationRegistry.php
+++ b/Registry/ProcessConfigurationRegistry.php
@@ -13,6 +13,7 @@ namespace CleverAge\ProcessBundle\Registry;
 use CleverAge\ProcessBundle\Configuration\ProcessConfiguration;
 use CleverAge\ProcessBundle\Configuration\TaskConfiguration;
 use CleverAge\ProcessBundle\Exception\MissingProcessException;
+use Psr\Log\LogLevel;
 
 /**
  * Build and holds all the process configurations
@@ -26,11 +27,10 @@ class ProcessConfigurationRegistry
     protected $processConfigurations = [];
 
     /**
-     * @param array $rawConfiguration
-     *
-     * @throws \CleverAge\ProcessBundle\Exception\MissingTaskConfigurationException
+     * @param array  $rawConfiguration
+     * @param string $defaultErrorStrategy
      */
-    public function __construct(array $rawConfiguration)
+    public function __construct(array $rawConfiguration, string $defaultErrorStrategy)
     {
         foreach ($rawConfiguration as $processCode => $rawProcessConfiguration) {
             /** @var TaskConfiguration[] $taskConfigurations */
@@ -45,8 +45,8 @@ class ProcessConfigurationRegistry
                     $rawTaskConfiguration['help'],
                     $rawTaskConfiguration['outputs'],
                     $rawTaskConfiguration['errors'],
-                    $rawTaskConfiguration['error_strategy'],
-                    $rawTaskConfiguration['log_errors']
+                    $rawTaskConfiguration['error_strategy'] ?? $defaultErrorStrategy,
+                    $rawTaskConfiguration['log_errors'] ? $rawTaskConfiguration['log_level'] : LogLevel::DEBUG
                 );
             }
 

--- a/Resources/config/services/registry.yml
+++ b/Resources/config/services/registry.yml
@@ -3,6 +3,7 @@ services:
         public: false
         arguments:
             - ~
+            - ~
 
     CleverAge\ProcessBundle\Registry\TransformerRegistry:
         public: false

--- a/Resources/tests/process/context.yml
+++ b/Resources/tests/process/context.yml
@@ -14,7 +14,7 @@ clever_age_process:
             end_point: data
             tasks:
                 data:
-                    service: '@cleverage_process.task.constant_output'
+                    service: '@CleverAge\ProcessBundle\Task\ConstantOutputTask'
                     options:
                         output: '{{ value1 }} is {{ value2 }}'
 
@@ -23,7 +23,7 @@ clever_age_process:
             end_point: data
             tasks:
                 data:
-                    service: '@cleverage_process.task.constant_output'
+                    service: '@CleverAge\ProcessBundle\Task\ConstantOutputTask'
                     options:
                         output:
                             key: '{{ value }}'
@@ -33,6 +33,6 @@ clever_age_process:
             end_point: data
             tasks:
                 data:
-                    service: '@cleverage_process.task.constant_output'
+                    service: '@CleverAge\ProcessBundle\Task\ConstantOutputTask'
                     options:
                         output: 'value is {{ value }}'

--- a/Tests/Task/ProcessExecutorTaskTest.php
+++ b/Tests/Task/ProcessExecutorTaskTest.php
@@ -30,7 +30,7 @@ class ProcessExecutorTaskTest extends AbstractProcessTest
     /**
      * Assert correct error if it doesn't match a good subprocess name
      *
-     * @expectedException \TypeError
+     * @expectedException \RuntimeException
      */
     public function testExecutorError()
     {


### PR DESCRIPTION
log_level replaces the log_error config, allowing more control over the way the process manager logs messages on behalf of tasks.

default_error_strategy can be used to changed the default error_strategy of all tasks to 'stop' instead of 'skip', which will be the default behavior in the next version.