### PR TITLE
Reset the state before execution

### DIFF
--- a/Manager/ProcessManager.php
+++ b/Manager/ProcessManager.php
@@ -362,8 +362,13 @@ class ProcessManager
     {
         $task = $taskConfiguration->getTask();
         $state = $taskConfiguration->getState();
+
+        // Reset state, TODO : wrap this in an explicit method ? where ?
         $state->setOutput(null);
         $state->setSkipped(false);
+        $state->setException(null);
+        $state->setErrorOutput(null);
+
         try {
             if (self::EXECUTE_PROCESS === $executionFlag) {
                 $this->processLogger->debug("Processing task {$taskConfiguration->getCode()}");

--- a/Model/ProcessState.php
+++ b/Model/ProcessState.php
@@ -206,6 +206,7 @@ class ProcessState
 
         return $this->hasErrorOutput();
     }
+
     /**
      * @return mixed
      */
@@ -266,9 +267,9 @@ class ProcessState
     }
 
     /**
-     * @param \Throwable $exception
+     * @param \Throwable|null $exception
      */
-    public function setException(\Throwable $exception)
+    public function setException(\Throwable $exception = null)
     {
         $this->exception = $exception;
     }
@@ -451,11 +452,11 @@ class ProcessState
     {
         @trigger_error('Deprecated method, use monolog processors instead', E_USER_DEPRECATED);
         $context = [
-            'process_id' => $this->processHistory->getId(),
-            'process_code' => $this->processConfiguration->getCode(),
+            'process_id'      => $this->processHistory->getId(),
+            'process_code'    => $this->processConfiguration->getCode(),
             'process_context' => $this->context,
-            'task_code' => $this->taskConfiguration->getCode(),
-            'task_service' => $this->taskConfiguration->getServiceReference(),
+            'task_code'       => $this->taskConfiguration->getCode(),
+            'task_service'    => $this->taskConfiguration->getServiceReference(),
         ];
 
         if ($this->hasErrorOutput()) {

--- a/Model/ProcessState.php
+++ b/Model/ProcessState.php
@@ -108,6 +108,25 @@ class ProcessState
     }
 
     /**
+     * Reset the state object
+     * To be used before execution
+     *
+     * @param bool $cleanInput
+     */
+    public function reset($cleanInput = true)
+    {
+        $this->setOutput(null);
+        $this->setSkipped(false);
+        $this->setException(null);
+        $this->setErrorOutput(null);
+
+        if($cleanInput) {
+            $this->setInput(null);
+            $this->setPreviousState(null);
+        }
+    }
+
+    /**
      * @return ProcessConfiguration
      */
     public function getProcessConfiguration()
@@ -452,11 +471,11 @@ class ProcessState
     {
         @trigger_error('Deprecated method, use monolog processors instead', E_USER_DEPRECATED);
         $context = [
-            'process_id'      => $this->processHistory->getId(),
-            'process_code'    => $this->processConfiguration->getCode(),
+            'process_id' => $this->processHistory->getId(),
+            'process_code' => $this->processConfiguration->getCode(),
             'process_context' => $this->context,
-            'task_code'       => $this->taskConfiguration->getCode(),
-            'task_service'    => $this->taskConfiguration->getServiceReference(),
+            'task_code' => $this->taskConfiguration->getCode(),
+            'task_service' => $this->taskConfiguration->getServiceReference(),
         ];
 
         if ($this->hasErrorOutput()) {

--- a/Resources/tests/process/exception_management.yml
+++ b/Resources/tests/process/exception_management.yml
@@ -2,7 +2,7 @@ clever_age_process:
     configurations:
         test.exception_management.set_exception_in_the_middle:
             entry_point: data
-            end_point: aggregator
+            end_point: input_aggregator
             tasks:
                 data:
                     service: '@CleverAge\ProcessBundle\Task\ConstantIterableOutputTask'
@@ -10,7 +10,7 @@ clever_age_process:
                         output:
                             - ['a', 'b', 'c']
                             - ['b', 'c', 'd']
-                            - 1
+                            - 1                     # triggers an error
                             - ['c', 'd', 'e']
                             - ['d', 'e', 'f']
                     outputs: [transformer]
@@ -22,6 +22,20 @@ clever_age_process:
                             implode:
                                 separator: ''
                     outputs: [aggregator]
+                    errors: [error_aggregator]
 
                 aggregator:
                     service: '@CleverAge\ProcessBundle\Task\AggregateIterableTask'
+                    outputs: [input_aggregator]
+
+                error_aggregator:
+                    service: '@CleverAge\ProcessBundle\Task\AggregateIterableTask'
+                    outputs: [input_aggregator]
+
+                input_aggregator:
+                    service: '@CleverAge\ProcessBundle\Task\InputAggregatorTask'
+                    options:
+                        input_codes:
+                            aggregator: success
+                            error_aggregator: errors
+

--- a/Resources/tests/process/exception_management.yml
+++ b/Resources/tests/process/exception_management.yml
@@ -1,0 +1,27 @@
+clever_age_process:
+    configurations:
+        test.exception_management.set_exception_in_the_middle:
+            entry_point: data
+            end_point: aggregator
+            tasks:
+                data:
+                    service: '@CleverAge\ProcessBundle\Task\ConstantIterableOutputTask'
+                    options:
+                        output:
+                            - ['a', 'b', 'c']
+                            - ['b', 'c', 'd']
+                            - 1
+                            - ['c', 'd', 'e']
+                            - ['d', 'e', 'f']
+                    outputs: [transformer]
+
+                transformer:
+                    service: '@CleverAge\ProcessBundle\Task\TransformerTask'
+                    options:
+                        transformers:
+                            implode:
+                                separator: ''
+                    outputs: [aggregator]
+
+                aggregator:
+                    service: '@CleverAge\ProcessBundle\Task\AggregateIterableTask'

--- a/Tests/ExceptionManagementTest.php
+++ b/Tests/ExceptionManagementTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace CleverAge\ProcessBundle\Tests;
+
+
+class ExceptionManagementTest extends AbstractProcessTest
+{
+    public function testSetExceptionInTheMiddle()
+    {
+        $result = $this->processManager->execute('test.exception_management.set_exception_in_the_middle');
+
+        self::assertEquals([
+            'abc',
+            'bcd',
+            'cde',
+            'def',
+        ], $result);
+    }
+}

--- a/Tests/ExceptionManagementTest.php
+++ b/Tests/ExceptionManagementTest.php
@@ -2,9 +2,15 @@
 
 namespace CleverAge\ProcessBundle\Tests;
 
-
+/**
+ * Asset the behavior of a process when there is an error
+ */
 class ExceptionManagementTest extends AbstractProcessTest
 {
+
+    /**
+     * Assert errors in the middle of an iteration does not skip subsequent loops and does not spam "error" flow
+     */
     public function testSetExceptionInTheMiddle()
     {
         $result = $this->processManager->execute('test.exception_management.set_exception_in_the_middle');
@@ -14,6 +20,10 @@ class ExceptionManagementTest extends AbstractProcessTest
             'bcd',
             'cde',
             'def',
-        ], $result);
+        ], $result['success']);
+
+        self::assertEquals([
+            1
+        ], $result['errors']);
     }
 }


### PR DESCRIPTION
Bug fixes:
* When there is an error in the middle of a transformer, it allow trigger skip for every subsequent loop ! 
* When there is an error in the middle of a transformer, error flow is spammed by failed value