### PR TITLE
Various fixes, see description

### DIFF
--- a/Registry/TransformerRegistry.php
+++ b/Registry/TransformerRegistry.php
@@ -22,13 +22,16 @@ use CleverAge\ProcessBundle\Transformer\TransformerInterface;
 class TransformerRegistry
 {
     /** @var TransformerInterface[] */
-    protected $transformers;
+    protected $transformers = [];
 
     /**
      * @param TransformerInterface $transformer
      */
     public function addTransformer(TransformerInterface $transformer)
     {
+        if (array_key_exists($transformer->getCode(), $this->transformers)) {
+            throw new \UnexpectedValueException("Transformer {$transformer->getCode()} is already defined");
+        }
         $this->transformers[$transformer->getCode()] = $transformer;
     }
 

--- a/Resources/tests/process/exception_management.yml
+++ b/Resources/tests/process/exception_management.yml
@@ -17,6 +17,7 @@ clever_age_process:
 
                 transformer:
                     service: '@CleverAge\ProcessBundle\Task\TransformerTask'
+                    error_strategy: skip
                     options:
                         transformers:
                             implode:

--- a/Task/Database/DatabaseReaderTask.php
+++ b/Task/Database/DatabaseReaderTask.php
@@ -17,6 +17,7 @@ use CleverAge\ProcessBundle\Model\ProcessState;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Driver\PDOStatement;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -96,8 +97,8 @@ class DatabaseReaderTask extends AbstractConfigurableTask implements IterableTas
         // Handle empty results
         if (false === $result) {
             $logContext = ['options' => $options];
-            $this->logger->error('Empty resultset for query', $logContext);
-            $state->setStopped(true);
+            $this->logger->log($options['empty_log_level'], 'Empty resultset for query', $logContext);
+            $state->setSkipped(true);
 
             return;
         }
@@ -177,6 +178,7 @@ class DatabaseReaderTask extends AbstractConfigurableTask implements IterableTas
                 'limit' => null,
                 'offset' => null,
                 'paginate' => null,
+                'empty_log_level' => LogLevel::WARNING,
             ]
         );
         $resolver->setAllowedTypes('connection', ['NULL', 'string']);
@@ -184,6 +186,19 @@ class DatabaseReaderTask extends AbstractConfigurableTask implements IterableTas
         $resolver->setAllowedTypes('paginate', ['NULL', 'int']);
         $resolver->setAllowedTypes('limit', ['NULL', 'integer']);
         $resolver->setAllowedTypes('offset', ['NULL', 'integer']);
+        $resolver->setAllowedValues(
+            'empty_log_level',
+            [
+                LogLevel::ALERT,
+                LogLevel::CRITICAL,
+                LogLevel::DEBUG,
+                LogLevel::EMERGENCY,
+                LogLevel::ERROR,
+                LogLevel::INFO,
+                LogLevel::NOTICE,
+                LogLevel::WARNING,
+            ]
+        );
     }
 
     /**

--- a/Task/Database/DatabaseUpdaterTask.php
+++ b/Task/Database/DatabaseUpdaterTask.php
@@ -51,12 +51,8 @@ class DatabaseUpdaterTask extends AbstractConfigurableTask
     {
         $statement = $this->initializeStatement($state);
 
-        // Handle empty results
         if (false === $statement->execute()) {
-            $this->logger->critical('Error while executing query: '.$statement->errorInfo());
-            $state->setStopped(true);
-
-            return;
+            throw new \RuntimeException("Error while executing query: {$statement->errorInfo()}");
         }
     }
 

--- a/Task/Doctrine/AbstractDoctrineQueryTask.php
+++ b/Task/Doctrine/AbstractDoctrineQueryTask.php
@@ -11,6 +11,7 @@
 namespace CleverAge\ProcessBundle\Task\Doctrine;
 
 use Doctrine\ORM\EntityRepository;
+use Psr\Log\LogLevel;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**

--- a/Task/Doctrine/AbstractDoctrineQueryTask.php
+++ b/Task/Doctrine/AbstractDoctrineQueryTask.php
@@ -39,12 +39,26 @@ abstract class AbstractDoctrineQueryTask extends AbstractDoctrineTask
                 'order_by' => [],
                 'limit' => null,
                 'offset' => null,
+                'empty_log_level' => LogLevel::WARNING,
             ]
         );
         $resolver->setAllowedTypes('criteria', ['array']);
         $resolver->setAllowedTypes('order_by', ['array']);
         $resolver->setAllowedTypes('limit', ['NULL', 'integer']);
         $resolver->setAllowedTypes('offset', ['NULL', 'integer']);
+        $resolver->setAllowedValues(
+            'empty_log_level',
+            [
+                LogLevel::ALERT,
+                LogLevel::CRITICAL,
+                LogLevel::DEBUG,
+                LogLevel::EMERGENCY,
+                LogLevel::ERROR,
+                LogLevel::INFO,
+                LogLevel::NOTICE,
+                LogLevel::WARNING,
+            ]
+        );
     }
 
     /**

--- a/Task/Doctrine/DoctrineReaderTask.php
+++ b/Task/Doctrine/DoctrineReaderTask.php
@@ -91,8 +91,8 @@ class DoctrineReaderTask extends AbstractDoctrineQueryTask implements IterableTa
         // Handle empty results
         if (false === $result) {
             $logContext = ['options' => $options];
-            $this->logger->error('Empty resultset for query', $logContext);
-            $state->setStopped(true);
+            $this->logger->log($options['empty_log_level'], 'Empty resultset for query', $logContext);
+            $state->setSkipped(true);
 
             return;
         }

--- a/Task/File/FolderBrowserTask.php
+++ b/Task/File/FolderBrowserTask.php
@@ -14,6 +14,7 @@ use CleverAge\ProcessBundle\Model\AbstractConfigurableTask;
 use CleverAge\ProcessBundle\Model\IterableTaskInterface;
 use CleverAge\ProcessBundle\Model\ProcessState;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -60,7 +61,7 @@ class FolderBrowserTask extends AbstractConfigurableTask implements IterableTask
         }
 
         if (!$this->files->valid()) {
-            $this->logger->warning("No item found in path {$options['folder_path']}");
+            $this->logger->log($options['empty_log_level'], "No item found in path {$options['folder_path']}");
             $state->setSkipped(true);
             $state->setErrorOutput($options['folder_path']);
 
@@ -129,8 +130,22 @@ class FolderBrowserTask extends AbstractConfigurableTask implements IterableTask
         $resolver->setDefaults(
             [
                 'name_pattern' => null,
+                'empty_log_level' => LogLevel::WARNING,
             ]
         );
         $resolver->setAllowedTypes('name_pattern', ['NULL', 'string']);
+        $resolver->setAllowedValues(
+            'empty_log_level',
+            [
+                LogLevel::ALERT,
+                LogLevel::CRITICAL,
+                LogLevel::DEBUG,
+                LogLevel::EMERGENCY,
+                LogLevel::ERROR,
+                LogLevel::INFO,
+                LogLevel::NOTICE,
+                LogLevel::WARNING,
+            ]
+        );
     }
 }


### PR DESCRIPTION
Fixing database and folder tasks handling of empty resultsets.
Transformer registry now prevents transformer overrides when using the same code twice.
Fixing tests config