### PR TITLE
Split additional_param in left ans right param

### DIFF
--- a/Resources/tests/transfomer/callback_transformer.yml
+++ b/Resources/tests/transfomer/callback_transformer.yml
@@ -1,0 +1,64 @@
+clever_age_process:
+    configurations:
+        test.callback_transformer.simple:
+            entry_point: transform
+            end_point: transform
+            tasks:
+                transform:
+                    service: '@CleverAge\ProcessBundle\Task\TransformerTask'
+                    error_strategy: stop
+                    options:
+                        transformers:
+                            callback:
+                                callback: '\CleverAge\ProcessBundle\Tests\Transformer\CallbackTransformerTest::doCallback'
+
+
+        test.callback_transformer.left_parameters:
+            entry_point: transform
+            end_point: transform
+            tasks:
+                transform:
+                    service: '@CleverAge\ProcessBundle\Task\TransformerTask'
+                    error_strategy: stop
+                    options:
+                        transformers:
+                            callback:
+                                callback: '\CleverAge\ProcessBundle\Tests\Transformer\CallbackTransformerTest::doCallback'
+                                left_parameters:
+                                    - '1'
+                                    - '2'
+
+
+        test.callback_transformer.right_parameters:
+            entry_point: transform
+            end_point: transform
+            tasks:
+                transform:
+                    service: '@CleverAge\ProcessBundle\Task\TransformerTask'
+                    error_strategy: stop
+                    options:
+                        transformers:
+                            callback:
+                                callback: '\CleverAge\ProcessBundle\Tests\Transformer\CallbackTransformerTest::doCallback'
+                                right_parameters:
+                                    - '4'
+                                    - '5'
+
+
+        test.callback_transformer.left_right_parameters:
+            entry_point: transform
+            end_point: transform
+            tasks:
+                transform:
+                    service: '@CleverAge\ProcessBundle\Task\TransformerTask'
+                    error_strategy: stop
+                    options:
+                        transformers:
+                            callback:
+                                callback: '\CleverAge\ProcessBundle\Tests\Transformer\CallbackTransformerTest::doCallback'
+                                left_parameters:
+                                    - '1'
+                                    - '2'
+                                right_parameters:
+                                    - '4'
+                                    - '5'

--- a/Tests/Transformer/CallbackTransformerTest.php
+++ b/Tests/Transformer/CallbackTransformerTest.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * This file is part of the CleverAge/ProcessBundle package.
+ *
+ * Copyright (C) 2017-2018 Clever-Age
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CleverAge\ProcessBundle\Tests\Transformer;
+
+use CleverAge\ProcessBundle\Tests\AbstractProcessTest;
+
+/**
+ * Test suite for CallbackTransformerTest
+ */
+class CallbackTransformerTest extends AbstractProcessTest
+{
+    /**
+     * @return string
+     */
+    public static function doCallback(): string
+    {
+        return implode('-', func_get_args());
+    }
+
+    /**
+     * Assert data is correctly filtered
+     */
+    public function testSimpleCallback()
+    {
+        $input = '3';
+
+        $result = $this->processManager->execute('test.callback_transformer.simple', $input);
+
+        self::assertEquals('3', $result);
+    }
+
+    /**
+     * Assert data is correctly filtered
+     */
+    public function testLeftParametersCallback()
+    {
+        $input = '3';
+
+        $result = $this->processManager->execute('test.callback_transformer.left_parameters', $input);
+
+        self::assertEquals('1-2-3', $result);
+    }
+
+    /**
+     * Assert data is correctly filtered
+     */
+    public function testRightParametersCallback()
+    {
+        $input = '3';
+
+        $result = $this->processManager->execute('test.callback_transformer.right_parameters', $input);
+
+        self::assertEquals('3-4-5', $result);
+    }
+
+    /**
+     * Assert data is correctly filtered
+     */
+    public function testLeftAndRightParametersCallback()
+    {
+        $input = '3';
+
+        $result = $this->processManager->execute('test.callback_transformer.left_right_parameters', $input);
+
+        self::assertEquals('1-2-3-4-5', $result);
+    }
+}

--- a/Transformer/CallbackTransformer.php
+++ b/Transformer/CallbackTransformer.php
@@ -10,9 +10,9 @@
 
 namespace CleverAge\ProcessBundle\Transformer;
 
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 /**
  * Convert input based on a callback
@@ -38,8 +38,13 @@ class CallbackTransformer implements ConfigurableTransformerInterface
         $this->configureOptions($resolver);
         $options = $resolver->resolve($options);
 
-        $parameters = $options['additional_parameters'];
-        array_unshift($parameters, $value);
+        if (array_key_exists('additional_parameters', $options)
+            && !array_key_exists('right_parameters', $options)) {
+            $options['right_parameters'] = $options['additional_parameters'];
+        }
+
+        $parameters = $options['left_parameters'];
+        array_push($parameters, $value, ...$options['right_parameters']);
 
         return \call_user_func_array($options['callback'], $parameters);
     }
@@ -80,9 +85,25 @@ class CallbackTransformer implements ConfigurableTransformerInterface
                 return $value;
             }
         );
-        $resolver->setDefaults([
-            'additional_parameters' => [],
-        ]);
+        $resolver->setDefaults(
+            [
+                'left_parameters' => [],
+                'right_parameters' => [],
+                'additional_parameters' => [],
+            ]
+        );
+        $resolver->setAllowedTypes('left_parameters', ['array']);
+        $resolver->setAllowedTypes('right_parameters', ['array']);
         $resolver->setAllowedTypes('additional_parameters', ['array']);
+
+        /** @noinspection PhpUnusedParameterInspection */
+        $resolver->setNormalizer(
+            'additional_parameters',
+            function (Options $options, $value) {
+                @trigger_error('The "additional_parameters" option is deprecated. Use "right_parameters" instead.', E_USER_DEPRECATED);
+
+                return $value;
+            }
+        );
     }
 }

--- a/Transformer/CallbackTransformer.php
+++ b/Transformer/CallbackTransformer.php
@@ -100,7 +100,9 @@ class CallbackTransformer implements ConfigurableTransformerInterface
         $resolver->setNormalizer(
             'additional_parameters',
             function (Options $options, $value) {
-                @trigger_error('The "additional_parameters" option is deprecated. Use "right_parameters" instead.', E_USER_DEPRECATED);
+                if ($value) {
+                    @trigger_error('The "additional_parameters" option is deprecated. Use "right_parameters" instead.', E_USER_DEPRECATED);
+                }
 
                 return $value;
             }


### PR DESCRIPTION
The option additional_parameters is splitted in two options left_parameters and right_parameters.
Now you can easily choose the position of the value in callback parameters.