### PR TITLE
Fixed callback transformer backcompat (with "additional_parameters")

### DIFF
--- a/Resources/tests/transfomer/callback_transformer.yml
+++ b/Resources/tests/transfomer/callback_transformer.yml
@@ -44,6 +44,20 @@ clever_age_process:
                                     - '4'
                                     - '5'
 
+        test.callback_transformer.additional_parameters:
+            entry_point: transform
+            end_point: transform
+            tasks:
+                transform:
+                    service: '@CleverAge\ProcessBundle\Task\TransformerTask'
+                    error_strategy: stop
+                    options:
+                        transformers:
+                            callback:
+                                callback: '\CleverAge\ProcessBundle\Tests\Transformer\CallbackTransformerTest::doCallback'
+                                additional_parameters:
+                                    - '7'
+                                    - '8'
 
         test.callback_transformer.left_right_parameters:
             entry_point: transform

--- a/Tests/Transformer/CallbackTransformerTest.php
+++ b/Tests/Transformer/CallbackTransformerTest.php
@@ -64,6 +64,18 @@ class CallbackTransformerTest extends AbstractProcessTest
     /**
      * Assert data is correctly filtered
      */
+    public function testAdditionalParametersCallback()
+    {
+        $input = '6';
+
+        $result = $this->processManager->execute('test.callback_transformer.additional_parameters', $input);
+
+        self::assertEquals('6-7-8', $result);
+    }
+
+    /**
+     * Assert data is correctly filtered
+     */
     public function testLeftAndRightParametersCallback()
     {
         $input = '3';

--- a/Transformer/CallbackTransformer.php
+++ b/Transformer/CallbackTransformer.php
@@ -38,8 +38,8 @@ class CallbackTransformer implements ConfigurableTransformerInterface
         $this->configureOptions($resolver);
         $options = $resolver->resolve($options);
 
-        if (array_key_exists('additional_parameters', $options)
-            && !array_key_exists('right_parameters', $options)) {
+        if (count($options['additional_parameters'])
+            && !count($options['right_parameters'])) {
             $options['right_parameters'] = $options['additional_parameters'];
         }
 


### PR DESCRIPTION
Compat broke with the addition of left/right parameters
Old additional_parameters is ignore and may result in a lot of failures