### PR TITLE
Better error strategy: stop

### DIFF
--- a/Model/ProcessHistory.php
+++ b/Model/ProcessHistory.php
@@ -143,6 +143,14 @@ class ProcessHistory
     }
 
     /**
+     * @return bool
+     */
+    public function isFailed()
+    {
+        return $this->state === self::STATE_FAILED;
+    }
+
+    /**
      * Get process duration in seconds
      *
      * @return int|null


### PR DESCRIPTION
Now outputing to error_outputs all the time and stopping/skipping only after error outputs is resolved