### PR TITLE
Fix the quickstart example

### DIFF
--- a/Documentation/01-quick_start.md
+++ b/Documentation/01-quick_start.md
@@ -81,9 +81,9 @@ clever_age_process:
                                         code: '[id]'
                                     slug:
                                         code:
-                                            - id
-                                            - firstname
-                                            - lastname
+                                            - '[id]'
+                                            - '[firstname]'
+                                            - '[lastname]'
                                         transformers:
                                             implode:
                                                 separator: '-'


### PR DESCRIPTION
ERROR: Transformation 'mapping' have failed: Cannot read property "id" from an array. Maybe you intended to write the property path as "[id]" instead.