### PR TITLE
Fixes #82: deprecate default error strategy = skip

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -81,6 +81,7 @@ class Configuration implements ConfigurationInterface
         $transformerListDefinition = $transformersArrayDefinition
             ->performNoDeepMerging()
             ->cannotBeOverwritten()
+            ->info('Unique custom transformer code')
             ->children();
 
         $this->appendTransformerConfigDefinition($transformerListDefinition);
@@ -117,6 +118,7 @@ class Configuration implements ConfigurationInterface
         // Process list
         $processListDefinition = $configurationsArrayDefinition
             ->performNoDeepMerging()
+            ->info('Unique custom process code')
             ->cannotBeOverwritten()
             ->children();
 
@@ -149,6 +151,7 @@ class Configuration implements ConfigurationInterface
         $taskListDefinition = $tasksArrayDefinition
             ->performNoDeepMerging()
             ->cannotBeOverwritten()
+            ->info('Unique custom task code')
             ->children();
 
         $this->appendTaskConfigDefinition($taskListDefinition);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -50,7 +50,12 @@ class Configuration implements ConfigurationInterface
         $definition = $rootNode->children();
 
         // Default error strategy
-        $definition->scalarNode('default_error_strategy')->defaultValue(TaskConfiguration::STRATEGY_SKIP)->end();
+        $definition->enumNode('default_error_strategy')
+            ->values([
+                TaskConfiguration::STRATEGY_SKIP,
+                TaskConfiguration::STRATEGY_STOP,
+            ])
+            ->isRequired();
 
         $this->appendRootProcessConfigDefinition($definition);
         $this->appendRootTransformersConfigDefinition($definition);
@@ -62,6 +67,7 @@ class Configuration implements ConfigurationInterface
 
     /**
      * "generic_transformers" root configuration
+     *
      * @param NodeBuilder $definition
      */
     protected function appendRootTransformersConfigDefinition(NodeBuilder $definition)
@@ -85,6 +91,7 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Single transformer configuration
+     *
      * @param NodeBuilder $definition
      */
     protected function appendTransformerConfigDefinition(NodeBuilder $definition)

--- a/Documentation/01-quick_start.md
+++ b/Documentation/01-quick_start.md
@@ -34,6 +34,22 @@ Some tasks and transformers use the main Symfony serializer service. You might n
 resolution might fail
 * https://symfony.com/doc/current/reference/configuration/framework.html#reference-serializer-enabled
 
+## Global configuration
+
+You can use `./bin/console config:dump-reference clever_age_process` to have a summary of current configuration.
+
+Aside from process and transformer configurations, there is the `default_error_strategy` setting that allow you to define
+behavior if a task encounter an error. Up to v3.0, the default value was to `skip` iterations with errors. Starting from v3.1, 
+the configuration should be defined by the user.
+
+We recommend to use the `stop` configuration (see bellow), and then specify task by task which one can be `skipped`.
+
+Recommended example :
+```yaml
+clever_age_process:
+    default_error_strategy: stop
+```
+
 ## Process definition
 
 Most of the work is done through the bundle configuration. 

--- a/Documentation/changelog/CHANGELOG-3.1.md
+++ b/Documentation/changelog/CHANGELOG-3.1.md
@@ -9,3 +9,6 @@ Fixes
 
 BC breaks
 ---------
+
+* [GIHTUB-82](https://github.com/cleverage/process-bundle/issues/82): the `default_error_strategy` is now mandatory. 
+If you have any doubt, you can use `default_error_strategy: skip` to keep previous behavior. 

--- a/Resources/tests/config.yml
+++ b/Resources/tests/config.yml
@@ -2,3 +2,6 @@ imports:
     - { resource: process/* }
     - { resource: task/* }
     - { resource: transfomer/* }
+
+clever_age_process:
+    default_error_strategy: stop


### PR DESCRIPTION
## Description

Skipping errors by default should be opt-in. This will force the user to choose.

## Requirements

* Documentation updates
  - [x] Reference
  - ~Cookbooks~
  - [x] Changelog
* [x] Unit tests (fix test env config)

## Breaking changes

* minor: to avoid any changes, use the `default_error_strategy: skip` config