### PR TITLE
Feature/group by aggregator task

### DIFF
--- a/Task/GroupByAggregateIterableTask.php
+++ b/Task/GroupByAggregateIterableTask.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace CleverAge\ProcessBundle\Task;
+
+use CleverAge\ProcessBundle\Model\AbstractConfigurableTask;
+use CleverAge\ProcessBundle\Model\BlockingTaskInterface;
+use CleverAge\ProcessBundle\Model\ProcessState;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+/**
+ * Attempt to aggregate inputs in an associative array with a key formed by configurable fields of the input.
+ * This task could be used to remove duplicates from the aggregate.
+ *
+ * @author Alix Mauro <amauro@clever-age.com>
+ */
+class GroupByAggregateIterableTask extends AbstractConfigurableTask implements BlockingTaskInterface
+{
+    /** @var string */
+    const GROUP_BY_OPTION = 'group_by_accessors';
+
+    /** @var array */
+    protected $result;
+
+    /** @var PropertyAccessorInterface */
+    protected $accessor;
+
+    /**
+     * @param PropertyAccessorInterface $accessor
+     */
+    public function __construct(PropertyAccessorInterface $accessor)
+    {
+        $this->result = [];
+        $this->accessor = $accessor;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute(ProcessState $state): void
+    {
+        $options = $this->getOptions($state);
+        $input = $state->getInput();
+        $groupByAccessors = $options[self::GROUP_BY_OPTION];
+
+        $keyParts = [];
+        foreach ($groupByAccessors as $groupByAccessor) {
+            try {
+                $keyParts[] = $this->accessor->getValue($input, $groupByAccessor);
+            } catch (\Exception $e) {
+                $state->addErrorContextValue('property', $groupByAccessor);
+                $state->setException($e);
+
+                return;
+            }
+        }
+
+        $key = implode('-', $keyParts);
+        $this->result[$key] = $input;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function proceed(ProcessState $state): void
+    {
+        if (0 === \count($this->result)) {
+            $state->setSkipped(true);
+        } else {
+            $state->setOutput($this->result);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setRequired(
+            [
+                self::GROUP_BY_OPTION,
+            ]
+        );
+        $resolver->setAllowedTypes(self::GROUP_BY_OPTION, ['array']);
+    }
+}


### PR DESCRIPTION
## Description

This PR implements a new task, GroupByAggregateIterableTask.
It's purpose is to aggregate a list of input into an array and removing duplicates.
```
                aggregate_and_dedupe_referentiel:
                    service: 'ImportExportBundle\Task\GroupByAggregateIterableTask'
                    options:
                        group_by_accessors:
                            - "[marque]"
                            - "[modele]"
                    outputs: [iterate_referentiel]
```
The array key is constructed from accessors given in the 'group_by_accessors' option.

## Requirements

* Documentation updates
  - [ ] Reference
  - [ ] Cookbooks
  - [ ] Changelog
* [ ] Unit tests 

## Breaking changes

No breaking changes.
