### PR TITLE
Fix - FolderBrowserTask: Accept array type for `name_pattern` option

### DIFF
--- a/Documentation/changelog/CHANGELOG-3.1.md
+++ b/Documentation/changelog/CHANGELOG-3.1.md
@@ -8,6 +8,8 @@ v3.1-dev
 
 ### Fixes
 
+* FolderBrowserTask: Accept array type for `name_pattern` option
+
 ### BC breaks
 
 v3.1.0

--- a/Task/File/FolderBrowserTask.php
+++ b/Task/File/FolderBrowserTask.php
@@ -135,7 +135,7 @@ class FolderBrowserTask extends AbstractConfigurableTask implements IterableTask
                 'empty_log_level' => LogLevel::WARNING,
             ]
         );
-        $resolver->setAllowedTypes('name_pattern', ['NULL', 'string']);
+        $resolver->setAllowedTypes('name_pattern', ['NULL', 'string', 'array']);
         $resolver->setAllowedValues(
             'empty_log_level',
             [


### PR DESCRIPTION
## Description

Fix - FolderBrowserTask: Accept array type for `name_pattern` option

## Requirements

* Documentation updates
  - [ ] Reference
  - [ ] Cookbooks
  - [x] Changelog
* [ ] Unit tests 

## Breaking changes

<!-- Please list here every breaking changes this PR might induce with minor/major labels -->
