### PR TITLE
Class Subprocessinstance: correct Symfony 5 compatibility by replacin…

### DIFF
--- a/Model/SubprocessInstance.php
+++ b/Model/SubprocessInstance.php
@@ -119,10 +119,9 @@ class SubprocessInstance
         }
 
         $arguments[] = $this->processCode;
+        $arguments = implode(' ', $arguments);
 
-        $this->process = new Process($arguments, null, null, $this->input);
-        $this->process->setCommandLine($this->process->getCommandLine());
-        $this->process->inheritEnvironmentVariables();
+        $this->process = Process::fromShellCommandline($arguments, null, null, $this->input);
         $this->process->enableOutput();
 
         return $this;


### PR DESCRIPTION
…g usage of removed Process functions.

## Description

Subprocessinstance is broken because it use some methods removed in SF5.
inheritEnvironmentVariables is useless now because processes always inherit env variables.
setCommandLine can be replaced by using fromShellCommandline. The catch is that it needs a string instead of an array of arguments.

## Requirements

* Documentation updates
  - [ ] Reference
  - [ ] Cookbooks
  - [ ] Changelog
* [ ] Unit tests 

## Breaking changes
No breaking change
