### PR TITLE
Fix Rules Transformer

### DIFF
--- a/src/Transformer/RulesTransformer.php
+++ b/src/Transformer/RulesTransformer.php
@@ -128,7 +128,7 @@ class RulesTransformer implements ConfigurableTransformerInterface
     /**
      * Test if a value match a rule.
      */
-    protected function matchRule(mixed $value, string|ParsedExpression $rule, bool $useValueAsVariable): bool
+    protected function matchRule(mixed $value, array $rule, bool $useValueAsVariable): bool
     {
         if (null !== $rule['condition']) {
             $expressionValues = $useValueAsVariable ? $value : [


### PR DESCRIPTION
## Description

Fix error of type in Transformer::matchRule(): Argument #2 ($rule)

## Error

Transformation 'mapping' have failed: For target property 'backend', transformation 'rules' have failed: CleverAge\ProcessBundle\Transformer\RulesTransformer::matchRule(): Argument #2 ($rule) must be of type Symfony\Component\ExpressionLanguage\ParsedExpression|string, array given, called in /var/www/html/vendor/cleverage/process-bundle/src/Transformer/RulesTransformer.php on line 39
