### PR TITLE
[#151] Replace monolog.logger by logger on CleverAge\ProcessBundle\Lo…

### DIFF
--- a/config/services/logger.yaml
+++ b/config/services/logger.yaml
@@ -29,7 +29,7 @@ services:
         tags:
             - { name: monolog.logger, channel: cleverage_process }
         arguments:
-            - '@monolog.logger'
+            - '@logger'
 
     cleverage_process.logger.task_logger:
         class: CleverAge\ProcessBundle\Logger\TaskLogger
@@ -37,4 +37,4 @@ services:
         tags:
             - { name: monolog.logger, channel: cleverage_process_task }
         arguments:
-            - '@monolog.logger'
+            - '@logger'


### PR DESCRIPTION
## Description
Fix #151 
Inject @logger instead og @monolog.logger to use defined channel instead of app channel for log.
## Requirements

* Documentation updates
  - [ ] Reference
  - [ ] Cookbooks
  - [ ] Changelog
* [ ] Unit tests 

## Breaking changes
