### PR TITLE
#158 Add dependency to symfony/service-contract

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,8 @@
     "symfony/serializer": "^6.4|^7.1",
     "symfony/stopwatch": "^6.4|^7.1",
     "symfony/validator": "^6.4|^7.1",
-    "symfony/yaml": "^6.4|^7.1"
+    "symfony/yaml": "^6.4|^7.1",
+    "symfony/service-contracts": ">=1.0.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "*",

--- a/src/Model/AbstractConfigurableTask.php
+++ b/src/Model/AbstractConfigurableTask.php
@@ -14,11 +14,12 @@ declare(strict_types=1);
 namespace CleverAge\ProcessBundle\Model;
 
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Allow the task to configure it's options, set default basic options for errors handling.
  */
-abstract class AbstractConfigurableTask implements InitializableTaskInterface
+abstract class AbstractConfigurableTask implements InitializableTaskInterface, ResetInterface
 {
     protected ?array $options = null;
 
@@ -28,6 +29,11 @@ abstract class AbstractConfigurableTask implements InitializableTaskInterface
     public function initialize(ProcessState $state): void
     {
         $this->getOptions($state);
+    }
+
+    public function reset(): void
+    {
+        $this->options = null;
     }
 
     protected function getOptions(ProcessState $state): ?array


### PR DESCRIPTION
## Description

Add dependency to symfony/service-contracts to reset options in case of symfony:messenger use
## Requirements

* Documentation updates
  - [ ] Reference
  - [ ] Cookbooks
  - [ ] Changelog
* [ ] Unit tests 

## Breaking changes